### PR TITLE
[pstl][tag_dispatch] Remove unnecessary traits

### DIFF
--- a/pstl/include/pstl/internal/execution_defs.h
+++ b/pstl/include/pstl/internal/execution_defs.h
@@ -26,88 +26,20 @@ inline namespace v1
 // 2.4, Sequential execution policy
 class sequenced_policy
 {
-  public:
-    // For internal use only
-    static constexpr std::false_type
-    __allow_unsequenced()
-    {
-        return std::false_type{};
-    }
-    static constexpr std::false_type
-    __allow_vector()
-    {
-        return std::false_type{};
-    }
-    static constexpr std::false_type
-    __allow_parallel()
-    {
-        return std::false_type{};
-    }
 };
 
 // 2.5, Parallel execution policy
 class parallel_policy
 {
-  public:
-    // For internal use only
-    static constexpr std::false_type
-    __allow_unsequenced()
-    {
-        return std::false_type{};
-    }
-    static constexpr std::false_type
-    __allow_vector()
-    {
-        return std::false_type{};
-    }
-    static constexpr std::true_type
-    __allow_parallel()
-    {
-        return std::true_type{};
-    }
 };
 
 // 2.6, Parallel+Vector execution policy
 class parallel_unsequenced_policy
 {
-  public:
-    // For internal use only
-    static constexpr std::true_type
-    __allow_unsequenced()
-    {
-        return std::true_type{};
-    }
-    static constexpr std::true_type
-    __allow_vector()
-    {
-        return std::true_type{};
-    }
-    static constexpr std::true_type
-    __allow_parallel()
-    {
-        return std::true_type{};
-    }
 };
 
 class unsequenced_policy
 {
-  public:
-    // For internal use only
-    static constexpr std::true_type
-    __allow_unsequenced()
-    {
-        return std::true_type{};
-    }
-    static constexpr std::true_type
-    __allow_vector()
-    {
-        return std::true_type{};
-    }
-    static constexpr std::false_type
-    __allow_parallel()
-    {
-        return std::false_type{};
-    }
 };
 
 // 2.8, Execution policy objects

--- a/pstl/include/pstl/internal/execution_impl.h
+++ b/pstl/include/pstl/internal/execution_impl.h
@@ -40,76 +40,6 @@ struct __is_random_access_iterator : decltype(__is_iterator_of<std::random_acces
 {
 };
 
-template <typename... _IteratorTypes>
-struct __is_forward_iterator : decltype(__is_iterator_of<std::forward_iterator_tag, _IteratorTypes...>(0))
-{
-};
-
-template <typename Policy>
-struct __policy_traits
-{
-};
-
-template <>
-struct __policy_traits<sequenced_policy>
-{
-    typedef std::false_type __allow_parallel;
-    typedef std::false_type __allow_unsequenced;
-    typedef std::false_type __allow_vector;
-};
-
-template <>
-struct __policy_traits<unsequenced_policy>
-{
-    typedef std::false_type __allow_parallel;
-    typedef std::true_type __allow_unsequenced;
-    typedef std::true_type __allow_vector;
-};
-
-template <>
-struct __policy_traits<parallel_policy>
-{
-    typedef std::true_type __allow_parallel;
-    typedef std::false_type __allow_unsequenced;
-    typedef std::false_type __allow_vector;
-};
-
-template <>
-struct __policy_traits<parallel_unsequenced_policy>
-{
-    typedef std::true_type __allow_parallel;
-    typedef std::true_type __allow_unsequenced;
-    typedef std::true_type __allow_vector;
-};
-
-template <typename _ExecutionPolicy>
-using __allow_vector =
-    typename __internal::__policy_traits<typename std::decay<_ExecutionPolicy>::type>::__allow_vector;
-
-template <typename _ExecutionPolicy>
-using __allow_unsequenced =
-    typename __internal::__policy_traits<typename std::decay<_ExecutionPolicy>::type>::__allow_unsequenced;
-
-template <typename _ExecutionPolicy>
-using __allow_parallel =
-    typename __internal::__policy_traits<typename std::decay<_ExecutionPolicy>::type>::__allow_parallel;
-
-template <typename _ExecutionPolicy, typename... _IteratorTypes>
-typename std::conjunction<__allow_vector<_ExecutionPolicy>,
-                          __is_random_access_iterator<_IteratorTypes>...>::type
-__is_vectorization_preferred(_ExecutionPolicy&&)
-{
-    return {};
-}
-
-template <typename _ExecutionPolicy, typename... _IteratorTypes>
-typename std::conjunction<__allow_parallel<_ExecutionPolicy>,
-                          __is_random_access_iterator<_IteratorTypes>...>::type
-__is_parallelization_preferred(_ExecutionPolicy&&)
-{
-    return {};
-}
-
 struct __serial_backend
 {
 };
@@ -141,20 +71,9 @@ struct __parallel_tag
     using __backend_tag = __par_backend_tag;
 };
 
-struct __parallel_forward_tag
-{
-    using __is_vector = std::false_type;
-    // backend tag can be change depending on
-    // TBB availability in the environment
-    using __backend_tag = __par_backend_tag;
-};
-
 template <class _IsVector, class... _IteratorTypes>
-using __tag_type =
-    typename std::conditional<__internal::__is_random_access_iterator<_IteratorTypes...>::value,
-                              __parallel_tag<_IsVector>,
-                              typename std::conditional<__is_forward_iterator<_IteratorTypes...>::value,
-                                                        __parallel_forward_tag, __serial_tag<_IsVector>>::type>::type;
+using __tag_type = typename std::conditional<__internal::__is_random_access_iterator<_IteratorTypes...>::value,
+                                             __parallel_tag<_IsVector>, __serial_tag<_IsVector>>::type;
 
 template <class... _IteratorTypes>
 __serial_tag</*_IsVector = */ std::false_type>

--- a/pstl/test/std/numerics/numeric.ops/scan.fail.cpp
+++ b/pstl/test/std/numerics/numeric.ops/scan.fail.cpp
@@ -14,16 +14,6 @@
 
 struct CustomPolicy
 {
-    constexpr std::false_type
-    __allow_vector()
-    {
-        return std::false_type{};
-    }
-    constexpr std::false_type
-    __allow_parallel()
-    {
-        return std::false_type{};
-    }
 } policy;
 
 int32_t

--- a/pstl/test/support/utils.h
+++ b/pstl/test/support/utils.h
@@ -1305,7 +1305,11 @@ static void
 invoke_if(Policy&&, F f)
 {
 #if defined(_PSTL_ICC_16_VC14_TEST_SIMD_LAMBDA_DEBUG_32_BROKEN) || defined(_PSTL_ICC_17_VC141_TEST_SIMD_LAMBDA_DEBUG_32_BROKEN)
-    __pstl::__internal::__invoke_if_not(__pstl::__internal::__allow_unsequenced<Policy>(), f);
+    using decay_policy = typename std::decay<Policy>::type;
+    using allow_unsequenced =
+        std::integral_constant<bool, (std::is_same<decay_policy, std::execution::unsequenced_policy>::value ||
+                                      std::is_same<decay_policy, std::execution::parallel_unsequenced_policy>::value)>;
+    __pstl::__internal::__invoke_if_not(allow_unsequenced{}, f);
 #else
     f();
 #endif


### PR DESCRIPTION
Remove all the unused traits/tags that I've found.

@MikeDvorskiy let's sync up and decide if there is any good reason to keep `allow_` functions within the policies.